### PR TITLE
Revert "Automatically withdraw license fees to owner address"

### DIFF
--- a/contracts/PFA.sol
+++ b/contracts/PFA.sol
@@ -144,6 +144,5 @@ abstract contract PFA is IPFA, LimitedOwnable {
         _licenseTimestamps[recipient_] = block.timestamp;
         emit License(recipient_);
         _transactionCount++;
-        payable(owner()).transfer(msg.value);
     }
 }

--- a/contracts/test/contract.PFA.test.js
+++ b/contracts/test/contract.PFA.test.js
@@ -1,6 +1,5 @@
 const SHARE = artifacts.require("SHARE");
 const PFAUnit = artifacts.require("PFAUnit");
-const PFACollection = artifacts.require("PFACollection");
 const DEFAULT_ADDRESS_INDEX = 0;
 const NON_OWNER_ADDRESS_INDEX = 1;
 const DEFAULT_TOKEN_ID = 0;
@@ -76,55 +75,6 @@ contract("PFAUnit", (accounts) => {
       );
     }
   );
-
-  specify("Licensing fee sent to owner", async () => {
-    const shareContract = await SHARE.deployed();
-    const assetContract = await PFAUnit.new();
-    const collection = await PFACollection.new();
-    await shareContract.setCodeVerificationEnabled(false);
-    await assetContract.initialize(
-      "/test/asset/uri" /* tokenURI_ */,
-      "1000000000" /* pricePerAccess_ */,
-      300 /* grantTTL_ */,
-      true /* supportsLicensing_ */,
-      "2000000000" /* pricePerLicense_ */,
-      shareContract.address /* shareContractAddress_ */
-    );
-    await collection.initialize(
-      [assetContract.address] /* addresses_ */,
-      "/test/collection/uri" /* tokenURI_ */,
-      "2000000000" /* pricePerAccess_ */,
-      300 /* grantTTL_ */,
-      false /* supportsLicensing_ */,
-      0 /* pricePerLicense_ */,
-      shareContract.address /* shareContractAddress_ */
-    );
-
-    // Initial owner balance
-    let initialOwnerBalance = await web3.eth.getBalance(
-      accounts[DEFAULT_ADDRESS_INDEX]
-    );
-
-    // License
-    await assetContract.license(collection.address, {
-      from: accounts[NON_OWNER_ADDRESS_INDEX],
-      value: "2000000000",
-    });
-
-    // Final owner balance
-    let finalOwnerBalance = await web3.eth.getBalance(
-      accounts[DEFAULT_ADDRESS_INDEX]
-    );
-
-    // Verify owner's increased balance
-    assert.equal(
-      finalOwnerBalance,
-      web3.utils
-        .toBN(initialOwnerBalance)
-        .add(web3.utils.toBN("2000000000"))
-        .toString()
-    );
-  });
 
   specify("Only owner sets price per access", async () => {
     const assetContract = await PFAUnit.deployed();


### PR DESCRIPTION
Reverts formless-eng/share-v1-core#30

Causing failures with paying out Playlist PFAs that are owned by S2RDs due to the gas limit imposed by .transfer() calls. 
Ref: https://ethereum.github.io/yellowpaper/paper.pdf