### PR TITLE
Add helper function that retrieves nextAvailableCommunitySlot

### DIFF
--- a/contracts/SL2RD.sol
+++ b/contracts/SL2RD.sol
@@ -180,7 +180,7 @@ contract SL2RD is
     }
 
     /// @notice Returns the next available community slot id.
-    function nextAvailableCommunitySlot() public view returns (uint256) {
+    function countAllocatedCommunitySlots() public view returns (uint256) {
         return _nextAvailableCommunitySlot;
     }
 

--- a/contracts/SL2RD.sol
+++ b/contracts/SL2RD.sol
@@ -179,6 +179,11 @@ contract SL2RD is
         return _communitySplitsBasisPoints.value;
     }
 
+    /// @notice Returns the next available community slot id.
+    function nextAvailableCommunitySlot() public view returns (uint256) {
+        return _nextAvailableCommunitySlot;
+    }
+
     /// @notice Returns the total ownership slots created for this contract.
     function totalSlots() public view afterInit returns (uint256) {
         return _totalSlots.value;

--- a/contracts/test/contract.SL2RD.test.js
+++ b/contracts/test/contract.SL2RD.test.js
@@ -102,9 +102,19 @@ contract("SL2RD", (accounts) => {
         (communitySplitsBasisPoints * ownerAddresses.length) / 10000
       );
 
+      // Distribution helper function test
       assert.equal(
         await splitContract.countAllocatedCommunitySlots(),
         0
+      );
+
+      // Increment the current count of community slots.
+      await splitContract.transferNextAvailable(accounts[i]);
+
+      // Ensure the counter retrieves the correct count.
+      assert.equal(
+        await splitContract.countAllocatedCommunitySlots(),
+        1
       );
     }
   );

--- a/contracts/test/contract.SL2RD.test.js
+++ b/contracts/test/contract.SL2RD.test.js
@@ -59,7 +59,7 @@ contract("SL2RD", (accounts) => {
   });
 
   specify(
-    "Retrieve communitySplitBasisPoints, initialSplitDistributionTable, totalSlots, totalCommunitySlots using getter functions.",
+    "Retrieve communitySplitBasisPoints, initialSplitDistributionTable, totalSlots, totalCommunitySlots, nextAvailableCommunitySlot using getter functions.",
     async () => {
       const shareContract = await SHARE.deployed();
       const splitContract = await SL2RD.new();
@@ -100,6 +100,11 @@ contract("SL2RD", (accounts) => {
       assert.equal(
         await splitContract.totalCommunitySlots(),
         (communitySplitsBasisPoints * ownerAddresses.length) / 10000
+      );
+
+      assert.equal(
+        await splitContract.nextAvailableCommunitySlot(),
+        0
       );
     }
   );

--- a/contracts/test/contract.SL2RD.test.js
+++ b/contracts/test/contract.SL2RD.test.js
@@ -103,7 +103,7 @@ contract("SL2RD", (accounts) => {
       );
 
       assert.equal(
-        await splitContract.nextAvailableCommunitySlot(),
+        await splitContract.countAllocatedCommunitySlots(),
         0
       );
     }

--- a/contracts/test/contract.SL2RD.test.js
+++ b/contracts/test/contract.SL2RD.test.js
@@ -109,7 +109,9 @@ contract("SL2RD", (accounts) => {
       );
 
       // Increment the current count of community slots.
-      await splitContract.transferNextAvailable(accounts[i]);
+      await splitContract.transferNextAvailable(
+        accounts[NON_OWNER_ADDRESS_INDEX]
+      );
 
       // Ensure the counter retrieves the correct count.
       assert.equal(


### PR DESCRIPTION
This will help add clarity to the progress of the distribution of community allocated slots.