### PR TITLE
Fix SL2RD multipart init gas cost

### DIFF
--- a/contracts/SL2RD.sol
+++ b/contracts/SL2RD.sol
@@ -238,7 +238,8 @@ contract SL2RD is
         }
 
         // Mint all of the slots to the corresponding address (default owner).
-        for (uint256 i = 0; i < _tokenIds.value.length; i++) {
+        uint256 startIndex = partitionIndex_ * tokenIds_.length;
+        for (uint256 i = startIndex; i < startIndex + tokenIds_.length; i++) {
             // Duplicate verification ensures tokenIds are minted once.
             if (_tokenOwners[_tokenIds.value[i]] == address(0)) {
                 emit MintingToken(_tokenIds.value[i], _addresses.value[i]);

--- a/contracts/test/contract.SL2RD.test.js
+++ b/contracts/test/contract.SL2RD.test.js
@@ -107,7 +107,7 @@ contract("SL2RD", (accounts) => {
         shareContract.address /* shareContractAddress_ */,
         operatorRegistry.address /* operatorRegistryAddress_ */
       );
-      for (let partitionIndex = 0; partitionIndex < 5; partitionIndex += 1) {
+      for (let partitionIndex = 0; partitionIndex < 10; partitionIndex += 1) {
         await splitContract.multipartAddPartition(
           partitionIndex /* partitionIndex_ */,
           ownerAddresses.slice(
@@ -137,6 +137,63 @@ contract("SL2RD", (accounts) => {
         );
       }
       await splitContract.multipartInitializationEnd();
+    } catch (error) {
+      console.log(error);
+      console.log(error.message);
+      assert(false, "Initialization with 1000 splits failed");
+    }
+  });
+
+  specify("Multipart contract initialization with 10000 splits", async () => {
+    const shareContract = await SHARE.deployed();
+    const operatorRegistry = await OperatorRegistry.deployed();
+    const splitContract = await SL2RD.new();
+    const uniformCollaboratorsIds = [];
+    const ownerAddresses = [];
+
+    for (let i = 0; i < 10000; i += 1) {
+      uniformCollaboratorsIds.push(Math.floor(Math.random() * 3));
+      ownerAddresses.push(accounts[0]);
+    }
+    console.log(uniformCollaboratorsIds);
+    try {
+      await splitContract.multipartInitializationBegin(
+        0 /* communitySplitsBasisPoints_ */,
+        shareContract.address /* shareContractAddress_ */,
+        operatorRegistry.address /* operatorRegistryAddress_ */
+      );
+      for (let partitionIndex = 0; partitionIndex < 100; partitionIndex += 1) {
+        await splitContract.multipartAddPartition(
+          partitionIndex /* partitionIndex_ */,
+          ownerAddresses.slice(
+            calculateSplitIndexUsingPartition(
+              partitionIndex,
+              MAX_SL2RD_PARTITION_SIZE,
+              0
+            ),
+            calculateSplitIndexUsingPartition(
+              partitionIndex,
+              MAX_SL2RD_PARTITION_SIZE,
+              MAX_SL2RD_PARTITION_SIZE
+            )
+          ) /* addresses_ */,
+          uniformCollaboratorsIds.slice(
+            calculateSplitIndexUsingPartition(
+              partitionIndex,
+              MAX_SL2RD_PARTITION_SIZE,
+              0
+            ),
+            calculateSplitIndexUsingPartition(
+              partitionIndex,
+              MAX_SL2RD_PARTITION_SIZE,
+              MAX_SL2RD_PARTITION_SIZE
+            )
+          ) /* tokenIds_ */
+        );
+      }
+      await splitContract.multipartInitializationEnd();
+      const distributionTable = await splitContract.splitDistributionTable();
+      assert(distributionTable.length === 10000);
     } catch (error) {
       console.log(error);
       console.log(error.message);


### PR DESCRIPTION
Prior to this fix, SL2RD multipart initialization gas cost increased slightly on each partition transaction, up until the block limit was reached, preventing 10,000 split contracts from being successfully created. 