### PR TITLE
Fix 2756

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ npm install
 truffle test
 ```
 
+## Running Individual Unit Tests
+
+```shell
+truffle test -g "License denial non-approved collection build"
+```
+
 ## Truffle interactive blockchain console
 
 To interact with deployed contracts you can use the truffle console:
@@ -152,6 +158,7 @@ The command above deploys the contracts as specified in `2_SL2RD_migration.js`.
 - `SHARE036` : `Payment to operator address during funding operation unsuccessful.`
 - `SHARE037` : `Transferring community allocated slots is prohibited until distribution process is complete.`
 - `SHARE038` : `Partition size must be less than or equal to the maximum partition size specified by this contract.`
+- `SHARE039` : `Access and license transactions may only be performed on approved contract builds.`
 
 ## Audits and Formal Verification
 

--- a/contracts/PFACollection.sol
+++ b/contracts/PFACollection.sol
@@ -151,7 +151,7 @@ contract PFACollection is PFA, IPFACollection, ERC721 {
         address owner = owner(); /* collection owner */
         address itemOwner = item.owner();
 
-        require(msg.value == _pricePerAccess.value, "SHARE010");
+        require(msg.value >= _pricePerAccess.value, "SHARE010");
 
         _currentAddressIndex =
             (_currentAddressIndex + 1) %

--- a/contracts/PFAUnit.sol
+++ b/contracts/PFAUnit.sol
@@ -76,7 +76,7 @@ contract PFAUnit is
         nonReentrant
         afterInit
     {
-        require(msg.value == _pricePerAccess.value, "SHARE005");
+        require(msg.value >= _pricePerAccess.value, "SHARE005");
         address owner = owner();
         // Since this contract is a LimitedOwnable, the code which
         // may reside at the owner address is restricted to approved

--- a/contracts/SHARE.sol
+++ b/contracts/SHARE.sol
@@ -124,7 +124,7 @@ contract SHARE is Ownable, ReentrancyGuard {
             isApprovedBuild(
                 contractAddress_,
                 CodeVerification.BuildType.PFA_UNIT
-            ) &&
+            ) ||
                 isApprovedBuild(
                     contractAddress_,
                     CodeVerification.BuildType.PFA_COLLECTION
@@ -155,7 +155,7 @@ contract SHARE is Ownable, ReentrancyGuard {
             isApprovedBuild(
                 licensorContract_,
                 CodeVerification.BuildType.PFA_UNIT
-            ) &&
+            ) ||
                 isApprovedBuild(
                     licensorContract_,
                     CodeVerification.BuildType.PFA_COLLECTION

--- a/contracts/SHARE.sol
+++ b/contracts/SHARE.sol
@@ -124,7 +124,7 @@ contract SHARE is Ownable, ReentrancyGuard {
             isApprovedBuild(
                 contractAddress_,
                 CodeVerification.BuildType.PFA_UNIT
-            ) ||
+            ) &&
                 isApprovedBuild(
                     contractAddress_,
                     CodeVerification.BuildType.PFA_COLLECTION
@@ -155,7 +155,7 @@ contract SHARE is Ownable, ReentrancyGuard {
             isApprovedBuild(
                 licensorContract_,
                 CodeVerification.BuildType.PFA_UNIT
-            ) ||
+            ) &&
                 isApprovedBuild(
                     licensorContract_,
                     CodeVerification.BuildType.PFA_COLLECTION

--- a/contracts/test/contract.PFA.test.js
+++ b/contracts/test/contract.PFA.test.js
@@ -23,10 +23,7 @@ contract("PFAUnit", (accounts) => {
       await assetContract.ownerOf(DEFAULT_TOKEN_ID)
     );
 
-    assert.equal(
-      await assetContract.pricePerAccess.call(),
-      1000000000
-    );
+    assert.equal(await assetContract.pricePerAccess.call(), 1000000000);
 
     assert.equal(
       await assetContract.tokenURI.call(DEFAULT_TOKEN_ID),
@@ -37,44 +34,35 @@ contract("PFAUnit", (accounts) => {
     assert.equal(await assetContract.symbol(), "PFA");
   });
 
-  specify(
-    "Contract initialization with zero licensing cost",
-    async () => {
-      const shareContract = await SHARE.deployed();
-      const assetContract = await PFAUnit.new();
-      await assetContract.initialize(
-        "/test/token/uri" /* tokenURI_ */,
-        "1000000000" /* pricePerAccess_ */,
-        300 /* grantTTL_ */,
-        true /* supportsLicensing_ */,
-        0 /* pricePerLicense_ */,
-        shareContract.address /* shareContractAddress_ */
-      );
+  specify("Contract initialization with zero licensing cost", async () => {
+    const shareContract = await SHARE.deployed();
+    const assetContract = await PFAUnit.new();
+    await assetContract.initialize(
+      "/test/token/uri" /* tokenURI_ */,
+      "1000000000" /* pricePerAccess_ */,
+      300 /* grantTTL_ */,
+      true /* supportsLicensing_ */,
+      0 /* pricePerLicense_ */,
+      shareContract.address /* shareContractAddress_ */
+    );
 
-      assert.equal(await assetContract.pricePerLicense.call(), 0);
-    }
-  );
+    assert.equal(await assetContract.pricePerLicense.call(), 0);
+  });
 
-  specify(
-    "Contract initialization with non-zero licensing cost",
-    async () => {
-      const shareContract = await SHARE.deployed();
-      const assetContract = await PFAUnit.new();
-      await assetContract.initialize(
-        "/test/token/uri" /* tokenURI_ */,
-        "1000000000" /* pricePerAccess_ */,
-        300 /* grantTTL_ */,
-        true /* supportsLicensing_ */,
-        "1000000000" /* pricePerLicense_ */,
-        shareContract.address /* shareContractAddress_ */
-      );
+  specify("Contract initialization with non-zero licensing cost", async () => {
+    const shareContract = await SHARE.deployed();
+    const assetContract = await PFAUnit.new();
+    await assetContract.initialize(
+      "/test/token/uri" /* tokenURI_ */,
+      "1000000000" /* pricePerAccess_ */,
+      300 /* grantTTL_ */,
+      true /* supportsLicensing_ */,
+      "1000000000" /* pricePerLicense_ */,
+      shareContract.address /* shareContractAddress_ */
+    );
 
-      assert.equal(
-        await assetContract.pricePerLicense.call(),
-        1000000000
-      );
-    }
-  );
+    assert.equal(await assetContract.pricePerLicense.call(), 1000000000);
+  });
 
   specify("Only owner sets price per access", async () => {
     const assetContract = await PFAUnit.deployed();
@@ -121,19 +109,22 @@ contract("PFAUnit", (accounts) => {
       from: accounts[DEFAULT_ADDRESS_INDEX],
     });
 
-    assert.equal(
-      await assetContract.tokenURI(DEFAULT_TOKEN_ID),
-      "/test/uri"
-    );
+    assert.equal(await assetContract.tokenURI(DEFAULT_TOKEN_ID), "/test/uri");
   });
 
   specify("Access denial", async () => {
-    const assetContract = await PFAUnit.deployed();
+    const shareContract = await SHARE.deployed();
+    const assetContract = await PFAUnit.new();
+    await assetContract.initialize(
+      "/test/token/uri" /* tokenURI_ */,
+      "1000000000" /* pricePerAccess_ */,
+      300 /* grantTTL_ */,
+      true /* supportsLicensing_ */,
+      0 /* pricePerLicense_ */,
+      shareContract.address /* shareContractAddress_ */
+    );
     const insufficientValueWei = "1000";
-    const exceedsValueWei = "2000000000";
     let insufficientValueWeiExceptionThrown = false;
-    let exceedsValueWeiExceptionThrown = false;
-
     try {
       await assetContract.access(
         DEFAULT_TOKEN_ID,
@@ -146,24 +137,7 @@ contract("PFAUnit", (accounts) => {
     } catch (error) {
       insufficientValueWeiExceptionThrown = true;
     }
-
-    try {
-      await assetContract.access(
-        DEFAULT_TOKEN_ID,
-        accounts[NON_OWNER_ADDRESS_INDEX],
-        {
-          from: accounts[NON_OWNER_ADDRESS_INDEX],
-          value: exceedsValueWei,
-        }
-      );
-    } catch (error) {
-      exceedsValueWeiExceptionThrown = true;
-    }
-
-    assert.isTrue(
-      insufficientValueWeiExceptionThrown &&
-        exceedsValueWeiExceptionThrown
-    );
+    assert.isTrue(insufficientValueWeiExceptionThrown);
   });
 
   specify("Access grant", async () => {
@@ -219,9 +193,7 @@ contract("PFAUnit", (accounts) => {
     );
 
     assert.isBelow(
-      Math.abs(
-        grantTimestamp.toString() - Math.round(Date.now() / 1000)
-      ),
+      Math.abs(grantTimestamp.toString() - Math.round(Date.now() / 1000)),
       GRANT_TTL_PRECISION_SEC
     );
   });


### PR DESCRIPTION
This PR resolves a known vulnerability related to non-approved PFA contract access transaction calls, and lifts the requirement of access transaction values equaling the specified contract price, which enables a "pay-what-you-want" model for price discovery.

The vulnerability details are outlined in 2756 (internal).