### PR TITLE
Support pay-what-you-want ERC20 payments by using sender allowance and forwarding actual amounts

### DIFF
--- a/contracts/ERC20Payable.sol
+++ b/contracts/ERC20Payable.sol
@@ -84,6 +84,13 @@ abstract contract ERC20Payable is IERC20Payable {
         );
     }
 
+
+    /// @notice Returns the ERC20 token allowance granted by the message sender to this contract
+    /// @return uint256 The spendable token amount approved for this contract
+    function _erc20AllowanceFromSender() internal view returns (uint256) {
+        return _erc20Token.allowance(msg.sender, address(this));
+    }
+
     /// @notice Transfers tokens from message sender to a recipient
     /// @param tokenRecipient_ Address that will receive the tokens
     /// @param tokenAmount_ Amount of tokens to transfer

--- a/contracts/PFACollection.sol
+++ b/contracts/PFACollection.sol
@@ -252,10 +252,12 @@ contract PFACollection is PFA, IPFACollection, ERC721 {
             // value and call the payable `access` function on the
             // child contract.
             uint256 itemPayment = item.pricePerAccess();
+            uint256 paymentAmount = _erc20AllowanceFromSender();
+            require(paymentAmount >= _pricePerAccess.value, "SHARE050");
             _transferERC20ThenApprove(
                 msg.sender /* tokenOwner_ */,
                 address(this) /* tokenSpender_ */,
-                _pricePerAccess.value /* totalTokenAmount_ */,
+                paymentAmount /* totalTokenAmount_ */,
                 itemAddress /* callableContractAddress_ */,
                 itemPayment /* callableTokenAmount_ */
             );
@@ -282,13 +284,8 @@ contract PFACollection is PFA, IPFACollection, ERC721 {
             }
             // Distribute the remaining payment to the collection owner
             // and update the grant timestamp.
-            require(
-                _erc20Token.transfer(
-                    owner,
-                    _pricePerAccess.value - itemPayment
-                ),
-                "SHARE048"
-            );
+            uint256 ownerPayment = _erc20Token.balanceOf(address(this));
+            require(_erc20Token.transfer(owner, ownerPayment), "SHARE048");
             (bool ownerPaymentSuccess, ) = payable(owner).call{
                 value: ERC20_PAYABLE_CALL_VALUE
             }("");
@@ -299,7 +296,7 @@ contract PFACollection is PFA, IPFACollection, ERC721 {
                 msg.sender,
                 owner,
                 _currentAddressIndex,
-                _pricePerAccess.value - item.pricePerAccess()
+                ownerPayment
             );
 
             _grantTimestamps[recipient_] = block.timestamp;

--- a/contracts/PFACollection.sol
+++ b/contracts/PFACollection.sol
@@ -283,8 +283,10 @@ contract PFACollection is PFA, IPFACollection, ERC721 {
                 emit ItemPaymentSkipped(itemOwner, address(item));
             }
             // Distribute the remaining payment to the collection owner
-            // and update the grant timestamp.
-            uint256 ownerPayment = _erc20Token.balanceOf(address(this));
+            // and update the grant timestamp. The item receives exactly
+            // its access price; the rest of the buyer-supplied payment
+            // belongs to the collection owner.
+            uint256 ownerPayment = paymentAmount - itemPayment;
             require(_erc20Token.transfer(owner, ownerPayment), "SHARE048");
             (bool ownerPaymentSuccess, ) = payable(owner).call{
                 value: ERC20_PAYABLE_CALL_VALUE

--- a/contracts/PFAUnit.sol
+++ b/contracts/PFAUnit.sol
@@ -98,8 +98,11 @@ contract PFAUnit is ERC721, PFA {
         // then transfer the tokens from the PFA to the payee.
         // Note that the one additional hop here is for
         // accounting and provenance purposes.
-        _transferERC20FromSender(address(this), _pricePerAccess.value);
-        _erc20Token.transfer(payeeAddress, _pricePerAccess.value);
+        uint256 paymentAmount = _erc20AllowanceFromSender();
+        require(paymentAmount >= _pricePerAccess.value, "SHARE050");
+        _transferERC20FromSender(address(this), paymentAmount);
+        uint256 payeeAmount = _erc20Token.balanceOf(address(this));
+        require(_erc20Token.transfer(payeeAddress, payeeAmount), "SHARE048");
 
         // If the payee is a split contract (rather than a simple wallet),
         // additional processing is required to distribute the payment.
@@ -123,7 +126,7 @@ contract PFAUnit is ERC721, PFA {
         _grantTimestamps[recipient_] = block.timestamp;
 
         // Emit events to log the payment and access grant
-        emit PaymentToOwner(payeeAddress, _pricePerAccess.value);
+        emit PaymentToOwner(payeeAddress, payeeAmount);
         emit Grant(recipient_, tokenId_);
         _transactionCount++;
     }

--- a/contracts/SHARE.sol
+++ b/contracts/SHARE.sol
@@ -206,14 +206,19 @@ contract SHARE is ERC20Payable, Ownable, ReentrancyGuard {
 
         if (useERC20) {
             require(msg.value == ERC20_PAYABLE_CALL_VALUE, "SHARE051");
+            uint256 paymentAmount = _erc20AllowanceFromSender();
+            require(paymentAmount >= grossPrice, "SHARE050");
+            uint256 assetPayment = paymentAmount - (grossPrice - netPrice);
             _transferERC20ThenApprove(
                 msg.sender /* tokenOwner_ */,
                 address(this) /* tokenSpender_ */,
-                grossPrice /* totalTokenAmount_ */,
+                paymentAmount /* totalTokenAmount_ */,
                 address(asset) /* callableContractAddress_ */,
-                netPrice /* callableTokenAmount_ */
+                assetPayment /* callableTokenAmount_ */
             );
             asset.access{value: ERC20_PAYABLE_CALL_VALUE}(tokenId_, recipient_);
+            grossPrice = paymentAmount;
+            netPrice = assetPayment;
         } else {
             require(msg.value >= grossPrice, "SHARE011");
             asset.access{value: netPrice}(tokenId_, recipient_);

--- a/contracts/test/ERC20/erc20.PFACollection.test.js
+++ b/contracts/test/ERC20/erc20.PFACollection.test.js
@@ -134,11 +134,14 @@ contract("PFACollection with ERC20 payments", (accounts) => {
   specify("Collection access accepts pay-what-you-want ERC20 payments", async () => {
     await _shareContract.setCodeVerificationEnabled(false);
     const collection = await PFACollection.new();
+    const childItemPrice = usdcToWei(0.5);
+    const collectionPrice = usdcToWei(1);
+    const underPricedPayment = usdcToWei(0.5);
     const paymentAmount = usdcToWei(1.5);
     await collection.initialize(
       [_assetContract.address] /* addresses_ */,
       "/test/collection/uri" /* tokenURI_ */,
-      usdcToWei(1) /* pricePerAccess_ */,
+      collectionPrice /* pricePerAccess_ */,
       300 /* grantTTL_ */,
       false /* supportsLicensing_ */,
       0 /* pricePerLicense_ */,
@@ -147,10 +150,26 @@ contract("PFACollection with ERC20 payments", (accounts) => {
 
     await _assetContract.setERC20ContractAddress(_mockERC20.address);
     await collection.setERC20ContractAddress(_mockERC20.address);
-    await _mockERC20.approve(_assetContract.address, usdcToWei(0.5), {
+    await _mockERC20.approve(_assetContract.address, childItemPrice, {
       from: _defaultOwner,
     });
     await _assetContract.license(collection.address);
+
+    let underPricedPaymentRejected = false;
+    try {
+      await _mockERC20.approve(collection.address, underPricedPayment, {
+        from: _defaultOwner,
+      });
+      await collection.access(UNIT_TOKEN_INDEX, _defaultOwner, {
+        from: _defaultOwner,
+        value: 0,
+      });
+    } catch (error) {
+      underPricedPaymentRejected = true;
+    }
+    assert.isTrue(underPricedPaymentRejected);
+    assert.isTrue(paymentAmount > collectionPrice);
+
     await _mockERC20.approve(collection.address, paymentAmount, {
       from: _defaultOwner,
     });
@@ -167,10 +186,10 @@ contract("PFACollection with ERC20 payments", (accounts) => {
       fromBlock: 0,
       toBlock: "latest",
     });
-    assert.equal(popEventFIFO(assetEvents).returnValues.value, usdcToWei(0.5));
+    assert.equal(popEventFIFO(assetEvents).returnValues.value, childItemPrice);
     assert.equal(
       popEventFIFO(collectionEvents, 1).returnValues.value,
-      usdcToWei(1)
+      paymentAmount - childItemPrice
     );
   });
 

--- a/contracts/test/ERC20/erc20.PFACollection.test.js
+++ b/contracts/test/ERC20/erc20.PFACollection.test.js
@@ -131,4 +131,47 @@ contract("PFACollection with ERC20 payments", (accounts) => {
       1
     );
   });
+  specify("Collection access accepts pay-what-you-want ERC20 payments", async () => {
+    await _shareContract.setCodeVerificationEnabled(false);
+    const collection = await PFACollection.new();
+    const paymentAmount = usdcToWei(1.5);
+    await collection.initialize(
+      [_assetContract.address] /* addresses_ */,
+      "/test/collection/uri" /* tokenURI_ */,
+      usdcToWei(1) /* pricePerAccess_ */,
+      300 /* grantTTL_ */,
+      false /* supportsLicensing_ */,
+      0 /* pricePerLicense_ */,
+      _shareContract.address /* shareContractAddress_ */
+    );
+
+    await _assetContract.setERC20ContractAddress(_mockERC20.address);
+    await collection.setERC20ContractAddress(_mockERC20.address);
+    await _mockERC20.approve(_assetContract.address, usdcToWei(0.5), {
+      from: _defaultOwner,
+    });
+    await _assetContract.license(collection.address);
+    await _mockERC20.approve(collection.address, paymentAmount, {
+      from: _defaultOwner,
+    });
+    await collection.access(UNIT_TOKEN_INDEX, _defaultOwner, {
+      from: _defaultOwner,
+      value: 0,
+    });
+
+    const assetEvents = await _assetContract.getPastEvents("PaymentToOwner", {
+      fromBlock: 0,
+      toBlock: "latest",
+    });
+    const collectionEvents = await collection.getPastEvents("Payment", {
+      fromBlock: 0,
+      toBlock: "latest",
+    });
+    assert.equal(popEventFIFO(assetEvents).returnValues.value, usdcToWei(0.5));
+    assert.equal(
+      popEventFIFO(collectionEvents, 1).returnValues.value,
+      usdcToWei(1)
+    );
+  });
+
 });

--- a/contracts/test/ERC20/erc20.SHARE.test.js
+++ b/contracts/test/ERC20/erc20.SHARE.test.js
@@ -312,14 +312,14 @@ contract("SHARE payable with ERC20", (accounts) => {
       await _assetContract.transferOwnership(_splitContract.address);
 
       // Execute bulk ERC20 payments to PFA asset contract.
+      const grossPricePerAccess = await _shareContract.grossPricePerAccess(
+        _assetContract.address,
+        UNIT_TOKEN_INDEX
+      );
       for (let i = 0; i < transactionCount; i += 1) {
-        await _mockERC20.approve(
-          _shareContract.address,
-          usdcToWei(Math.ceil(1.05 * paymentValue)),
-          {
-            from: _defaultOwner,
-          }
-        );
+        await _mockERC20.approve(_shareContract.address, grossPricePerAccess, {
+          from: _defaultOwner,
+        });
         await _shareContract.access(
           _assetContract.address,
           UNIT_TOKEN_INDEX,
@@ -340,22 +340,19 @@ contract("SHARE payable with ERC20", (accounts) => {
           ).length,
           1
         );
-        _splitContract
-          .getPastEvents("Payment", {
-            fromBlock: 0,
-            toBlock: "latest",
-          })
-          .then((events) => {
-            assert.equal(events.length, (i + 1) * batchSize);
-            for (let j = 0; j < batchSize; j++) {
-              const event = events[events.length - batchSize + j];
-              assert.equal(
-                event.returnValues.value,
-                usdcToWei(paymentValue) / batchSize, // Each recipient gets an equal share
-                "Incorrect payment value"
-              );
-            }
-          });
+        const events = await _splitContract.getPastEvents("Payment", {
+          fromBlock: 0,
+          toBlock: "latest",
+        });
+        assert.equal(events.length, (i + 1) * batchSize);
+        for (let j = 0; j < batchSize; j++) {
+          const event = events[events.length - batchSize + j];
+          assert.equal(
+            event.returnValues.value,
+            usdcToWei(paymentValue) / batchSize, // Each recipient gets an equal share
+            "Incorrect payment value"
+          );
+        }
       }
     }
   );

--- a/contracts/test/ERC20/erc20.SHARE.test.js
+++ b/contracts/test/ERC20/erc20.SHARE.test.js
@@ -81,6 +81,85 @@ contract("SHARE payable with ERC20", (accounts) => {
     );
   });
 
+  specify("Direct PFA access accepts pay-what-you-want ERC20 payments", async () => {
+    const buyer = accounts[1];
+    const paymentAmount = usdcToWei(2);
+    await _mockERC20.transfer(buyer, paymentAmount, {
+      from: _defaultOwner,
+    });
+
+    const ownerBalanceBefore = web3.utils.toBN(
+      await _mockERC20.balanceOf(_defaultOwner)
+    );
+    await _mockERC20.approve(_assetContract.address, paymentAmount, {
+      from: buyer,
+    });
+    await _assetContract.access(UNIT_TOKEN_INDEX, buyer, {
+      from: buyer,
+      value: 0,
+    });
+
+    const ownerBalanceAfter = web3.utils.toBN(
+      await _mockERC20.balanceOf(_defaultOwner)
+    );
+    assert.equal(
+      ownerBalanceAfter.sub(ownerBalanceBefore).toString(),
+      paymentAmount.toString()
+    );
+  });
+
+  specify("SHARE access accepts pay-what-you-want ERC20 payments", async () => {
+    const buyer = accounts[1];
+    const paymentAmount = web3.utils.toBN(usdcToWei(2));
+    const grossPrice = web3.utils.toBN(
+      await _shareContract.grossPricePerAccess(
+        _assetContract.address,
+        UNIT_TOKEN_INDEX
+      )
+    );
+    const netPrice = web3.utils.toBN(await _assetContract.pricePerAccess());
+    const protocolFee = grossPrice.sub(netPrice);
+    const expectedAssetPayment = paymentAmount.sub(protocolFee);
+
+    await _mockERC20.transfer(buyer, paymentAmount, {
+      from: _defaultOwner,
+    });
+
+    const ownerBalanceBefore = web3.utils.toBN(
+      await _mockERC20.balanceOf(_defaultOwner)
+    );
+    const shareBalanceBefore = web3.utils.toBN(
+      await _mockERC20.balanceOf(_shareContract.address)
+    );
+    await _mockERC20.approve(_shareContract.address, paymentAmount, {
+      from: buyer,
+    });
+    await _shareContract.access(
+      _assetContract.address,
+      UNIT_TOKEN_INDEX,
+      buyer,
+      {
+        from: buyer,
+        value: 0,
+      }
+    );
+
+    const ownerBalanceAfter = web3.utils.toBN(
+      await _mockERC20.balanceOf(_defaultOwner)
+    );
+    const shareBalanceAfter = web3.utils.toBN(
+      await _mockERC20.balanceOf(_shareContract.address)
+    );
+    assert.equal(
+      ownerBalanceAfter.sub(ownerBalanceBefore).toString(),
+      expectedAssetPayment.toString()
+    );
+    assert.equal(
+      shareBalanceAfter.sub(shareBalanceBefore).toString(),
+      protocolFee.toString()
+    );
+  });
+
   specify("Access grant with ERC20 payment", async () => {
     await _mockERC20.approve(
       _shareContract.address,


### PR DESCRIPTION
### Motivation
- Allow users to pay ERC20 tokens with a variable (pay-what-you-want) amount instead of forcing exact configured prices by using the caller's approved allowance as the payment source.
- Ensure downstream contracts and owners receive the actual amounts transferred while preserving protocol fee calculation and distribution.

### Description
- Added helper `function _erc20AllowanceFromSender()` in `ERC20Payable` to return `ERC20.allowance(msg.sender, address(this))`.
- Modified `PFACollection` to read the sender's allowance (`paymentAmount`), require it meets the minimum `_pricePerAccess.value`, call `_transferERC20ThenApprove` with the full `paymentAmount`, and forward the collection owner payment using the contract's ERC20 balance; updated emitted event values to reflect actual transferred amounts.
- Modified `PFAUnit` to use the sender allowance as `paymentAmount`, transfer that amount into the contract, forward the contract's ERC20 balance to the payee, and update emitted events to report the real received amount.
- Modified `SHARE.access` to compute `paymentAmount` from allowance, require it covers `grossPrice`, compute `assetPayment = paymentAmount - (grossPrice - netPrice)` to preserve protocol fee, call `_transferERC20ThenApprove` with `paymentAmount` and `assetPayment`, and update `grossPrice`/`netPrice` to reflect the actual transferred values for subsequent fee distribution.
- Updated tests to cover pay-what-you-want ERC20 flows by adding `Direct PFA access accepts pay-what-you-want ERC20 payments`, `SHARE access accepts pay-what-you-want ERC20 payments`, and `Collection access accepts pay-what-you-want ERC20 payments` scenarios.

### Testing
- Ran ERC20 unit tests including the added specs `Direct PFA access accepts pay-what-you-want ERC20 payments`, `SHARE access accepts pay-what-you-want ERC20 payments`, and `Collection access accepts pay-what-you-want ERC20 payments` and they passed.
- Existing ERC20 tests including `Access grant with ERC20 payment` and `Access denial with ERC20 payment` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a294e5c1a308326a231a3b25c955097)